### PR TITLE
Adding more flexible sendCommand variant to check the response as START of the response or anywhere in the response

### DIFF
--- a/ATcommands.cpp
+++ b/ATcommands.cpp
@@ -79,3 +79,32 @@ bool ATcommands::sendCommand(char *command, char *reply, uint16_t timeout) {
   if (replyMatch) return true;
   else return false;
 }
+
+bool ATcommands::sendCommand(char *command, char *reply, bool startonly, uint16_t timeout) {
+  while(mySerial->available()) mySerial->read(); // Clear input buffer
+
+  Serial.print(F("\t---> ")); Serial.println(command);
+  if (newline) mySerial->println(command);
+  else mySerial->print(command);
+
+  uint8_t idx = 0;
+  bool replyMatch = false;
+  timer = millis();
+
+  while (!replyMatch && millis() - timer < timeout) {
+  	if (mySerial->available()) {
+  	  replybuffer[idx] = mySerial->read();
+  	  idx++;
+      if (startonly) {
+        if (strcmp(replybuffer, reply) == 0) replyMatch = true;
+      } else {
+        if (strstr(replybuffer, reply) != NULL) replyMatch = true;
+      }
+  	}
+  }
+
+  Serial.print(F("\t<--- ")); Serial.println(replybuffer);
+
+  if (replyMatch) return true;
+  else return false;
+}

--- a/ATcommands.h
+++ b/ATcommands.h
@@ -15,6 +15,7 @@ class ATcommands {
     bool sendBlindCommand(char *command);
     bool sendCommand(char *command, uint16_t timeout = default_timeout_ms);
     bool sendCommand(char *command, char *reply, uint16_t timeout = default_timeout_ms);
+    bool sendCommand(char *command, char *reply, bool startonly, uint16_t timeout = default_timeout_ms);
   
   private:
     int8_t _rst;

--- a/ATcommands.h
+++ b/ATcommands.h
@@ -15,7 +15,7 @@ class ATcommands {
     bool sendBlindCommand(char *command);
     bool sendCommand(char *command, uint16_t timeout = default_timeout_ms);
     bool sendCommand(char *command, char *reply, uint16_t timeout = default_timeout_ms);
-    bool sendCommand(char *command, char *reply, bool startonly, uint16_t timeout = default_timeout_ms);
+    bool sendCommand(char *command, char *reply, bool startonly, uint16_t timeout);
   
   private:
     int8_t _rst;

--- a/Examples/sendATcommands/sendATcommands.ino
+++ b/Examples/sendATcommands/sendATcommands.ino
@@ -44,8 +44,14 @@ void setup() {
   if (!module.sendCommand("AT")) Serial.println(F("Command failed!"));
   delay(1000);
 
-  // Send command with timeout and check if module's response matches the desired
+  // Send command with timeout and check if module's response contains the desired (check the start)
   if (!module.sendCommand("AT", "OK", 1000)) Serial.println(F("Command failed!"));
+
+  // Send command with timeout and check if module's response start with the desired
+  if (!module.sendCommand("AT", "OK", true, 1000)) Serial.println(F("Command failed!"));
+
+  // Send command with timeout and check if module's response contains the desired
+  if (!module.sendCommand("AT", "OK", false, 1000)) Serial.println(F("Command failed!"));
 }
 
 void loop() {


### PR DESCRIPTION
the current sendCommand with response variant only cater one condition (either start or anywhere depending on user decision to comment line 72 or 73.

I've added a new sendCommand variant that takes a boolean argument to indicate whether to check the response value to be at the start or anywhere inside the response... a slight change from the existing sendCommand routine.